### PR TITLE
Refer to scikit-learn with full PyPI package name (fix #32)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
         "numpy",
         "pandas",
         "requests",
-        "sklearn",
+        "scikit-learn",
     ],
     tests_require=[
         "requests-mock",


### PR DESCRIPTION
This should resolve #32 (I don't know the package source that well, but it seemed to be the only occurence of `sklearn` I could find).

From what it looked like, I think `scikit-learn` could also be moved to be a development dependency if it is only needed to run tests? (in `extras_require` in `setup.py`)? 🤔